### PR TITLE
Alternative string spec

### DIFF
--- a/lib/Devel/Optic.pm
+++ b/lib/Devel/Optic.pm
@@ -11,7 +11,7 @@ use Devel::Size qw(total_size);
 use PadWalker qw(peek_my);
 
 use constant {
-    EXEMPLAR => [ map { { a => [1, 2, 3, qw(foo bar baz)] } } 1 .. 5 ],
+    'EXEMPLAR'   => [ map +{ a => [ 1, 2, 3, qw(foo bar baz) ] }, 1 .. 5 ],
 };
 
 use constant {

--- a/t/003-parse-string-spec.t
+++ b/t/003-parse-string-spec.t
@@ -1,0 +1,62 @@
+#!/usr/bin/perl
+use strict;
+use warnings;
+use Test::More 'tests' => 6;
+use Devel::Optic;
+
+is_deeply(
+    Devel::Optic::_parse_string_spec(q!'foo'!),
+    [
+        { 'type' => 'key', 'value' => 'foo' },
+    ],
+    'String: \'foo\'',
+);
+
+is_deeply(
+    Devel::Optic::_parse_string_spec(q!32!),
+    [
+        { 'type' => 'index', 'value' => 32 },
+    ],
+    'String: 32',
+);
+
+is_deeply(
+    Devel::Optic::_parse_string_spec(q!'foo'/32!),
+    [
+        { 'type' => 'key',   'value' => 'foo' },
+        { 'type' => 'index', 'value' => 32    },
+    ],
+    'String: \'foo\'/32',
+);
+
+is_deeply(
+    Devel::Optic::_parse_string_spec(q!'foo'/3/'bar'!),
+    [
+        { 'type' => 'key',   'value' => 'foo' },
+        { 'type' => 'index', 'value' => 3     },
+        { 'type' => 'key',   'value' => 'bar' },
+    ],
+    'String: \'foo\'/3/\'bar\'',
+);
+
+is_deeply(
+    Devel::Optic::_parse_string_spec(q!'foo'/3/'b\/ar'!),
+    [
+        { 'type' => 'key',   'value' => 'foo'  },
+        { 'type' => 'index', 'value' => 3      },
+        { 'type' => 'key',   'value' => 'b/ar' },
+    ],
+    'String: \'foo\'/3/\b\/ar\'',
+);
+
+is_deeply(
+    Devel::Optic::_parse_string_spec(q!'fo o'/3/'ba\/r\''/4/5!),
+    [
+        { 'type' => 'key',   'value' => 'fo o'   },
+        { 'type' => 'index', 'value' => 3        },
+        { 'type' => 'key',   'value' => 'ba/r\'' },
+        { 'type' => 'index', 'value' => 4        },
+        { 'type' => 'index', 'value' => 5        },
+    ],
+    'String: \'fo o\'/3/\'ba\/r\'/4/5',
+);


### PR DESCRIPTION
    'string'/30/'another key'/'string\'with\/escaped\'\/chars/10

This spec:

1. Allows escaping chars
2. Allows / and ' to be used
3. Understands difference between keys and indices
4. Simpler, I think
5. Uses a full lexer and parser, so has metadata on the items

However, this pull request just adds it (with a few tests) but doesn't integrate it yet. I wasn't sure how and didn't have the time to do it right now.